### PR TITLE
fix:theme-switcher

### DIFF
--- a/src/components/theme-switcher.tsx
+++ b/src/components/theme-switcher.tsx
@@ -1,45 +1,53 @@
 'use client'
 import { IconMoon, IconSun } from 'justd-icons'
+import { useEffect, useState } from 'react'
 import { Button } from 'ui'
-import { useEffect, useState } from "react";
 
 export function ThemeSwitcher() {
-    const [theme, setTheme] = useState("light");
-    const [isMounted, setIsMounted] = useState(false);
+  const [theme, setTheme] = useState('light')
+  const [isMounted, setIsMounted] = useState(false)
 
-    useEffect(() => {
-        const savedTheme = localStorage.getItem("theme") ?? "light";
-        setTheme(savedTheme);
-        setIsMounted(true);
-    }, []);
-
-    if (!isMounted) {
-        return null;
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme') || 'light'
+    setTheme(savedTheme)
+    if (savedTheme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
     }
+    setIsMounted(true)
+  }, [])
 
-    const handleSwitchTheme = () => {
-        setTheme(theme === "light" ? "dark" : "light");
-    };
+  if (!isMounted) return null
 
-    useEffect(() => {
-        if (theme === "dark") {
-            document.documentElement.classList.add("dark");
-        } else {
-            document.documentElement.classList.remove("dark");
-        }
-        localStorage.setItem("theme", theme);
-    }, [theme]);
+  const handleSwitchTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light'
+    setTheme(newTheme)
+    if (newTheme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+    localStorage.setItem('theme', newTheme)
+  }
 
-    return (
-        <Button
-            appearance="outline"
-            size="square-petite"
-            aria-label={'Switch to ' + theme === 'light' ? 'dark' : 'light' + 'mode'}
-            onPress={handleSwitchTheme}
-        >
-            <IconSun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"/>
-            <IconMoon
-                className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"/>
-        </Button>
-    )
+  return (
+    <Button
+      appearance="outline"
+      size="square-petite"
+      aria-label={'Switch to ' + theme === 'light' ? 'dark' : 'light' + 'mode'}
+      onPress={handleSwitchTheme}
+    >
+      <IconSun
+        className={`h-[1.2rem] w-[1.2rem] transition-all ${
+          theme === 'dark' ? 'opacity-0 scale-0 -rotate-90' : 'opacity-100 scale-100 rotate-0'
+        }`}
+      />
+      <IconMoon
+        className={`absolute h-[1.2rem] w-[1.2rem] transition-all ${
+          theme === 'dark' ? 'opacity-100 scale-100 rotate-0' : 'opacity-0 scale-0 rotate-90'
+        }`}
+      />
+    </Button>
+  )
 }

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -38,7 +38,7 @@ const { title } = Astro.props
     <title>{title}</title>
   </head>
   <body class="font-sans antialiased">
-      <Navigation />
+      <Navigation client:load/>
       <slot />
   </body>
 </html>


### PR DESCRIPTION
**Fix Astro Starter - Theme Switcher Component**

- Fixed the theme switcher `Rendered more hooks than during the previous render` error.
- Fixed the theme switcher logic to ensure the sun and moon icons rotate and toggle visibility correctly.
- Added an `client:load` to ThemeSwitcher import on BaseLayout. 

Result:
https://github.com/user-attachments/assets/0c339880-d9c7-4a43-9d0d-e8418ed93573

Great job on the project—it's looking really good!

